### PR TITLE
Fix issue 2: LRUCache will evict entries even though not full

### DIFF
--- a/repoze/lru/__init__.py
+++ b/repoze/lru/__init__.py
@@ -38,10 +38,6 @@ class LRUCache(object):
             return default
         pos, val = datum
         self.clock[pos]['ref'] = True
-        hand = pos + 1
-        if hand > self.maxpos:
-            hand = 0
-        self.hand = hand
         return val
 
     def put(self, key, val, _marker=_marker):


### PR DESCRIPTION
get() does not set self.hand any more, so no entries will be evicted before the cache is really full.
