### PR TITLE
initial tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,35 +1,15 @@
 [tox]
 envlist = 
-    py26,py27,py32,pypy,cover,docs
+    py26,py27,py32,py33,pypy
 
 [testenv]
 commands = 
-    python setup.py test -q
-deps =
-    setuptools-git
-    virtualenv
+    python -Wd setup.py test -q
 
 [testenv:cover]
 basepython =
     python2.6
 commands = 
-    nosetests --with-xunit --with-xcoverage
+    python -Wd setup.py nosetests --with-xunit --with-xcoverage
 deps =
-    setuptools-git
-    virtualenv
     nose
-    coverage
-    nosexcover
-
-# we separate coverage into its own testenv because a) "last run wins" wrt
-# cobertura jenkins reporting and b) pypy and jython can't handle any
-# combination of versions of coverage and nosexcover that i can find.
-
-[testenv:docs]
-basepython =
-    python2.6
-commands = 
-    sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
-    sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
-deps =
-    Sphinx


### PR DESCRIPTION
Hi,

I would like to submit  tox.ini configuration. 
So that testing using tox  for multiple version of python is simpler. 

Just install tox system wide and run `tox`.

The tests pass on python 3.3 and pypy.

Have a nice day , Sir
