### PR TITLE
Expose cache object on the wrapped function, so end users can also extra...

### DIFF
--- a/repoze/lru/__init__.py
+++ b/repoze/lru/__init__.py
@@ -290,6 +290,7 @@ class lru_cache(object):
         lru_cached.__module__ = f.__module__
         lru_cached.__name__ = f.__name__
         lru_cached.__doc__ = f.__doc__
+        lru_cached._cache = cache
         return lru_cached
 
 

--- a/repoze/lru/tests.py
+++ b/repoze/lru/tests.py
@@ -522,6 +522,14 @@ class DecoratorTests(unittest.TestCase):
         self.assertEqual(result, 2)
         self.assertEqual(len(cache), 2)
 
+    def test_cache_attr(self):
+        cache = DummyLRUCache()
+        decorator = self._makeOne(0, cache)
+        def wrapped(key):
+            return key
+        decorated = decorator(wrapped)
+        self.assertEqual(decorated._cache, cache)
+
     def test_multiargs(self):
         cache = DummyLRUCache()
         decorator = self._makeOne(0, cache)


### PR DESCRIPTION
Expose cache object on the wrapped function, so end users can also extract cache performance data easily.
