### PR TITLE
fix crash on memoizing partial

### DIFF
--- a/repoze/lru/__init__.py
+++ b/repoze/lru/__init__.py
@@ -287,9 +287,14 @@ class lru_cache(object):
                 val = f(*arg)
                 cache.put(arg, val)
             return val
-        lru_cached.__module__ = f.__module__
-        lru_cached.__name__ = f.__name__
-        lru_cached.__doc__ = f.__doc__
+        try:
+            lru_cached.__module__ = f.__module__
+            lru_cached.__name__ = f.__name__
+            lru_cached.__doc__ = f.__doc__
+        except AttributeError:
+            # functools.partial objects don't have __module__ or __name__.
+            # Ignore.
+            pass
         return lru_cached
 
 

--- a/repoze/lru/tests.py
+++ b/repoze/lru/tests.py
@@ -562,6 +562,16 @@ class DecoratorTests(unittest.TestCase):
         self.assertEqual(result3, 2 * "hello")
         self.assertTrue(stop - start > 0.1)
 
+    def test_partial(self):
+        """lru_cache decorator must not crash on functools.partial instances"""
+        def add(a,b):
+            return a + b
+        from functools import partial
+        from repoze.lru import lru_cache
+        add_five = partial(add, 5)
+        decorated = lru_cache(20)(add_five)
+        self.assertEqual(decorated(3), 8)
+
 
 class DummyLRUCache(dict):
 


### PR DESCRIPTION
functools.partial objects don't have **module** or **name**

this is arguably a problem with functools, but accomodate it
anyway.
