### PR TITLE
new features, support for unbounded memoization, cache decorator supports *args and **kwargs

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -106,3 +106,4 @@ Contributors
 - Tres Seaver, 2011/02/22
 - Joel Bohman, 2011/08/16
 - Julien Tayon, 2012/07/04
+- Cosmin Basca, 2014/07/12

--- a/repoze/lru/__init__.py
+++ b/repoze/lru/__init__.py
@@ -170,7 +170,7 @@ class LRUCache(Cache):
             # We have no lock, but worst thing that can happen is that we
             # set another key's entry to False.
             self.clock_refs[entry[0]] = False
-            # else: key was not in cache. Nothing to do.
+        # else: key was not in cache. Nothing to do.
 
 
 class ExpiringLRUCache(Cache):
@@ -305,7 +305,7 @@ class ExpiringLRUCache(Cache):
             # We have no lock, but worst thing that can happen is that we
             # set another key's entry to False.
             self.clock_refs[entry[0]] = False
-            # else: key was not in cache. Nothing to do.
+        # else: key was not in cache. Nothing to do.
 
 
 class lru_cache(object):

--- a/repoze/lru/__version__.py
+++ b/repoze/lru/__version__.py
@@ -1,0 +1,2 @@
+version = (0, 7, 1)
+str_version = '.'.join(['{0}'.format(v) for v in version])

--- a/repoze/lru/__version__.py
+++ b/repoze/lru/__version__.py
@@ -1,2 +1,0 @@
-version = (0, 7, 1)
-str_version = '.'.join(['{0}'.format(v) for v in version])

--- a/repoze/lru/tests.py
+++ b/repoze/lru/tests.py
@@ -539,6 +539,28 @@ class DecoratorTests(unittest.TestCase):
         self.assertEqual(result, (3, 4, 5))
         self.assertEqual(len(cache), 1)
 
+    def test_multiargs_keywords(self):
+        cache = DummyLRUCache()
+        decorator = self._makeOne(0, cache)
+        def moreargs(*args, **kwargs):
+            return args, kwargs
+        decorated = decorator(moreargs)
+        result = decorated(3, 4, 5, a=1, b=2, c=3)
+        self.assertEqual(cache[((3, 4, 5), frozenset([ ('a',1), ('b',2), ('c',3) ]))], ((3, 4, 5), {'a':1, 'b':2, 'c':3}))
+        self.assertEqual(result, ((3, 4, 5), {'a':1, 'b':2, 'c':3}))
+        self.assertEqual(len(cache), 1)
+
+    def test_multiargs_keywords_unhashable(self):
+        cache = DummyLRUCache()
+        decorator = self._makeOne(0, cache)
+        def moreargs(*args, **kwargs):
+            return args, kwargs
+        decorated = decorator(moreargs)
+        result = decorated(3, 4, 5, a=1, b=[1,2,3])
+        self.assertEqual(len(cache), 0)
+        self.assertEqual(result, ((3, 4, 5), {'a':1, 'b':[1,2,3]}))
+
+
     def test_expiry(self):
         #When timeout is given, decorator must eventually forget entries
         @self._makeOne(1, None, timeout=0.1)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ except:
 testing_extras = ['nose', 'coverage']
 
 setup(name='repoze.lru',
-      version='0.6+',
+      version='0.7',
       description='A tiny LRU cache implementation and decorator',
       long_description=README + '\n\n' +  CHANGES,
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-##############################################################################
+# #############################################################################
 #
 # Copyright (c) 2009 Agendaless Consulting and Contributors.
 # All Rights Reserved.
@@ -26,22 +26,25 @@ except:
 
 testing_extras = ['nose', 'coverage']
 
+str_version = None
+execfile('repoze/lru/__version__.py')
+
 setup(name='repoze.lru',
-      version='0.7',
+      version=str_version,
       description='A tiny LRU cache implementation and decorator',
-      long_description=README + '\n\n' +  CHANGES,
+      long_description=README + '\n\n' + CHANGES,
       classifiers=[
-        "Intended Audience :: Developers",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "License :: Repoze Public License",
-        ],
+          "Intended Audience :: Developers",
+          "Programming Language :: Python",
+          "Programming Language :: Python :: 2.6",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3.2",
+          "Programming Language :: Python :: 3.3",
+          "Programming Language :: Python :: Implementation :: CPython",
+          "Programming Language :: Python :: Implementation :: PyPy",
+          "License :: Repoze Public License",
+      ],
       keywords='repoze lru cache',
       author="Agendaless Consulting",
       author_email="repoze-dev@lists.repoze.org",
@@ -51,14 +54,14 @@ setup(name='repoze.lru',
       include_package_data=True,
       namespace_packages=['repoze'],
       zip_safe=False,
-      tests_require = [],
-      install_requires = [],
+      tests_require=[],
+      install_requires=[],
       test_suite="repoze.lru",
-      entry_points = """\
+      entry_points="""\
       """,
-      extras_require = {
-        'testing':  testing_extras,
-        'docs':  ['Sphinx',],
+      extras_require={
+          'testing': testing_extras,
+          'docs': ['Sphinx', ],
       }
 )
 

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,8 @@ except:
 
 testing_extras = ['nose', 'coverage']
 
-str_version = None
-execfile('repoze/lru/__version__.py')
-
 setup(name='repoze.lru',
-      version=str_version,
+      version='0.7.1',
       description='A tiny LRU cache implementation and decorator',
       long_description=README + '\n\n' + CHANGES,
       classifiers=[


### PR DESCRIPTION
included UnbondedCache (a simple unbounded and unexpiring cache)

added new abstract base class (interface): Cache
LRUCache, ExpiringLRUCache and UnboundedCache inherit from it

modified lru_cache decorator to support _args and *_kwargs, not just *args
added memoized member to CacheMaker
