### PR TITLE
Fix changelog filename in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 try:
     README = open(os.path.join(here, 'README.rst')).read()
-    CHANGES = open(os.path.join(here, 'CHANGESrsttxt')).read()
+    CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
 except:
     README = ''
     CHANGES = ''


### PR DESCRIPTION
The description on PyPI [is blank for 0.7](https://pypi.org/project/repoze.lru/0.7/#description) because of a typo in the changelog ([compare to 0.6](https://pypi.org/project/repoze.lru/0.6/#description)).